### PR TITLE
Get Case ID from the received values param

### DIFF
--- a/casetokens.php
+++ b/casetokens.php
@@ -241,6 +241,12 @@ function casetokens_civicrm_tokens(&$tokens) {
  */
 function casetokens_civicrm_tokenvalues(&$values, $cids, $job = NULL, $tokens = array(), $context = NULL) {
   $caseId = _casetokens_get_case_id();
+
+  if (!$caseId && !empty($values)) {
+    $caseContactData = current($values);
+    $caseId = isset($caseContactData['case.id']) ? $caseContactData['case.id'] : null;
+  }
+
   if ($caseId && !empty($tokens['case_roles'])) {
     // Get client(s)
     $caseContact = civicrm_api3('CaseContact', 'get', array(


### PR DESCRIPTION
## Overview
This PR provides a solution to the problem detected while trying to send an email message with case tokens, using a CiviRule.

## Before
When the case token are attempted to be parsed for an email fired inside a CiviRule, the case ID can't be detected, neither from GET params nor `entryUrl` (which is what `_casetokens_get_case_id` function checks)
That has in consequence that the token values for cases (`case_roles`, `subject`, `details`, etc) are not parsed at all: https://github.com/civicrm/org.civicrm.casetokens/blob/master/casetokens.php#L244
_Example_
![image](https://user-images.githubusercontent.com/74304572/113837778-5f163680-97b8-11eb-9564-76bfb1b42219.png)

## After
Examining the `$values` params, we are able to see that we receive the case ID, associated with the contact, in the key `case.id`.
This is provided by the email extension used to send the messages: https://lab.civicrm.org/extensions/emailapi/-/blob/1.22/api/v3/Email/Send.php
Despite this is dependent on the code of this external extension, these are usually used together, and the check has no cost nor side-effects. 
Also, despite we are referring to version 1.22, this is still present on the last update of version 1 (1.25). There is a version "2" with other changes, but in a separate set of tags. 
_Example_
![image](https://user-images.githubusercontent.com/74304572/113837815-68070800-97b8-11eb-929f-ef1296bf04bd.png)
